### PR TITLE
Make a copy of deprecated integration tests config files

### DIFF
--- a/integration_tests/at_config.yml
+++ b/integration_tests/at_config.yml
@@ -1,0 +1,47 @@
+atom_data: kurucz_cd23_chianti_H_He.h5
+model:
+  abundances:
+    filename: abundances.dat
+    filetype: simple_ascii
+    type: file
+  structure:
+    filename: densities.dat
+    filetype: simple_ascii
+    type: file
+    v_inner_boundary: 12000.000 km/s
+    v_outer_boundary: 35000.000 km/s
+montecarlo:
+  black_body_sampling:
+    num: 1000000
+    start: 1 angstrom
+    stop: 1000000 angstrom
+  convergence_strategy:
+    damping_constant: 1.0
+    fraction: 0.8
+    hold_iterations: 3
+    t_inner:
+      damping_constant: 1.0
+    threshold: 0.05
+    type: specific
+  iterations: 20
+  last_no_of_packets: 5.0e+5
+  no_of_packets: 5.0e+4
+  no_of_virtual_packets: 3
+  nthreads: 16
+  seed: 23111963
+plasma:
+  disable_electron_scattering: false
+  excitation: dilute-lte
+  ionization: nebular
+  line_interaction_type: downbranch
+  radiative_rates_type: dilute-blackbody
+spectrum:
+  num: 10000
+  start: 500 angstrom
+  stop: 20000 angstrom
+supernova:
+  luminosity_requested: 8.675 log_lsun
+  luminosity_wavelength_end: 6500.000 angstrom
+  luminosity_wavelength_start: 3500.000 angstrom
+  time_explosion: 6.800 day
+tardis_config_version: v1.0

--- a/integration_tests/paper1_downbranch_config.yml
+++ b/integration_tests/paper1_downbranch_config.yml
@@ -1,0 +1,91 @@
+# NOTE: Config file from Paper 1, there have been significant changes
+# in config schema, hence legacy schema at places has been commented out.
+
+#New configuration for TARDIS based on YAML
+#IMPORTANT any pure floats need to have a +/- after the e e.g. 2e+5
+#Hopefully pyyaml will fix this soon.
+---
+
+# #Currently only simple1d is allowed
+# config_type: simple1d
+
+
+# atom_data: /home/wkerzend/projects/tardis_paper/kurucz_atom_chianti_many.h5
+atom_data: kurucz_atom_chianti_many.h5
+
+
+model:
+#  file:
+#    type: artis
+#    structure_fname: /home/wkerzend/projects/tardis/artis_model.dat
+#    abundances_fname: /home/wkerzend/projects/tardis/artis_abundances.dat
+  abundances:
+    filename: ../paper1_macroatom/abundances.dat
+    filetype: artis
+    type: file
+
+  structure:
+    filename: ../paper1_macroatom/densities.dat
+    filetype: artis
+    type: file
+#    v_lowest: 9000.0 km/s
+#    v_highest: 22000.0 km/s
+
+    v_inner_boundary: 9000.000 km/s
+    v_outer_boundary: 22000.000 km/s
+#    split_shells: 1
+
+
+plasma:
+#  disable_electron_scattering: no
+  disable_electron_scattering: false
+#  type: nebular
+  ionization: nebular
+  radiative_rates_type: detailed
+  line_interaction_type: downbranch
+#    nlte:
+#        species : []
+  excitation: dilute-lte
+
+
+montecarlo:
+  black_body_sampling:
+    start: 1 angstrom
+#    end: 1000000 angstrom
+    stop: 1000000 angstrom
+#    samples: 1.e+6
+    num: 1000000
+
+  convergence_strategy:
+    damping_constant: 1.0
+    fraction: 1.0
+#    hold: 3
+    hold_iterations: 3
+    t_inner:
+      damping_constant: 0.5
+    threshold: -0.01
+    lock_t_inner_cycles: 3
+    t_inner_update_exponent: -0.5
+    type: specific
+
+  no_of_packets : 1.0e+7
+  no_of_virtual_packets: 1
+  iterations: 30
+#  seed: 23111963171620
+  seed: 23111963
+
+
+spectrum:
+#  bins : 10000
+  num: 10000
+  start: 500 angstrom
+#  end : 20000 angstrom
+  stop: 20000 angstrom
+
+supernova:
+  luminosity_requested: 9.34 log_lsun
+  time_explosion: 11.12 day
+  distance : 1 Mpc
+
+# Required now:
+tardis_config_version: v1.0

--- a/integration_tests/paper1_macroatom_config.yml
+++ b/integration_tests/paper1_macroatom_config.yml
@@ -1,0 +1,91 @@
+# NOTE: Config file from Paper 1, there have been significant changes
+# in config schema, hence legacy schema at places has been commented out.
+
+#New configuration for TARDIS based on YAML
+#IMPORTANT any pure floats need to have a +/- after the e e.g. 2e+5
+#Hopefully pyyaml will fix this soon.
+---
+
+# #Currently only simple1d is allowed
+# config_type: simple1d
+
+
+# atom_data: /home/wkerzend/projects/tardis_paper/kurucz_atom_chianti_many.h5
+atom_data: kurucz_atom_chianti_many.h5
+
+
+model:
+#  file:
+#    type: artis
+#    structure_fname: /home/wkerzend/projects/tardis/artis_model.dat
+#    abundances_fname: /home/wkerzend/projects/tardis/artis_abundances.dat
+  abundances:
+    filename: abundances.dat
+    filetype: artis
+    type: file
+
+  structure:
+    filename: densities.dat
+    filetype: artis
+    type: file
+#    v_lowest: 9000.0 km/s
+#    v_highest: 22000.0 km/s
+
+    v_inner_boundary: 9000.000 km/s
+    v_outer_boundary: 22000.000 km/s
+#    split_shells: 1
+
+
+plasma:
+#  disable_electron_scattering: no
+  disable_electron_scattering: false
+#  type: nebular
+  ionization: nebular
+  radiative_rates_type: detailed
+  line_interaction_type: macroatom
+#    nlte:
+#        species : []
+  excitation: dilute-lte
+
+
+montecarlo:
+  black_body_sampling:
+    start: 1 angstrom
+#    end: 1000000 angstrom
+    stop: 1000000 angstrom
+#    samples: 1.e+6
+    num: 1000000
+
+  convergence_strategy:
+    damping_constant: 1.0
+    fraction: 1.0
+#    hold: 3
+    hold_iterations: 3
+    t_inner:
+      damping_constant: 0.5
+    threshold: -0.01
+    lock_t_inner_cycles: 3
+    t_inner_update_exponent: -0.5
+    type: specific
+
+  no_of_packets : 1.0e+7
+  no_of_virtual_packets: 1
+  iterations: 30
+#  seed: 23111963171620
+  seed: 23111963
+
+
+spectrum:
+#  bins : 10000
+  num: 10000
+  start: 500 angstrom
+#  end : 20000 angstrom
+  stop: 20000 angstrom
+
+supernova:
+  luminosity_requested: 9.34 log_lsun
+  time_explosion: 11.12 day
+  distance : 1 Mpc
+
+# Required now:
+tardis_config_version: v1.0

--- a/integration_tests/paper1_scatter_config.yml
+++ b/integration_tests/paper1_scatter_config.yml
@@ -1,0 +1,91 @@
+# NOTE: Config file from Paper 1, there have been significant changes
+# in config schema, hence legacy schema at places has been commented out.
+
+#New configuration for TARDIS based on YAML
+#IMPORTANT any pure floats need to have a +/- after the e e.g. 2e+5
+#Hopefully pyyaml will fix this soon.
+---
+
+# #Currently only simple1d is allowed
+# config_type: simple1d
+
+
+# atom_data: /home/wkerzend/projects/tardis_paper/kurucz_atom_chianti_many.h5
+atom_data: kurucz_atom_chianti_many.h5
+
+
+model:
+#  file:
+#    type: artis
+#    structure_fname: /home/wkerzend/projects/tardis/artis_model.dat
+#    abundances_fname: /home/wkerzend/projects/tardis/artis_abundances.dat
+  abundances:
+    filename: ../paper1_macroatom/abundances.dat
+    filetype: artis
+    type: file
+
+  structure:
+    filename: ../paper1_macroatom/densities.dat
+    filetype: artis
+    type: file
+#    v_lowest: 9000.0 km/s
+#    v_highest: 22000.0 km/s
+
+    v_inner_boundary: 9000.000 km/s
+    v_outer_boundary: 22000.000 km/s
+#    split_shells: 1
+
+
+plasma:
+#  disable_electron_scattering: no
+  disable_electron_scattering: false
+#  type: nebular
+  ionization: nebular
+  radiative_rates_type: detailed
+  line_interaction_type: scatter
+#    nlte:
+#        species : []
+  excitation: dilute-lte
+
+
+montecarlo:
+  black_body_sampling:
+    start: 1 angstrom
+#    end: 1000000 angstrom
+    stop: 1000000 angstrom
+#    samples: 1.e+6
+    num: 1000000
+
+  convergence_strategy:
+    damping_constant: 1.0
+    fraction: 1.0
+#    hold: 3
+    hold_iterations: 3
+    t_inner:
+      damping_constant: 0.5
+    threshold: -0.01
+    lock_t_inner_cycles: 3
+    t_inner_update_exponent: -0.5
+    type: specific
+
+  no_of_packets : 1.0e+7
+  no_of_virtual_packets: 1
+  iterations: 30
+#  seed: 23111963171620
+  seed: 23111963
+
+
+spectrum:
+#  bins : 10000
+  num: 10000
+  start: 500 angstrom
+#  end : 20000 angstrom
+  stop: 20000 angstrom
+
+supernova:
+  luminosity_requested: 9.34 log_lsun
+  time_explosion: 11.12 day
+  distance : 1 Mpc
+
+# Required now:
+tardis_config_version: v1.0

--- a/integration_tests/w7_config.yml
+++ b/integration_tests/w7_config.yml
@@ -1,0 +1,39 @@
+atom_data: kurucz_cd23_chianti_H_He.h5
+model:
+  abundances:
+    filename: abundances.dat
+    filetype: simple_ascii
+    type: file
+  structure:
+    filename: densities.dat
+    filetype: simple_ascii
+    type: file
+    v_inner_boundary: 12000.000 km/s
+    v_outer_boundary: 35000.000 km/s
+montecarlo:
+  black_body_sampling:
+    num: 1000000
+    start: 1 angstrom
+    stop: 1000000 angstrom
+  iterations: 20
+  last_no_of_packets: 2.0e+5
+  no_of_packets: 4.0e+4
+  no_of_virtual_packets: 10
+  nthreads: 2
+  seed: 23111963
+plasma:
+  initial_t_rad: 10000 K
+  initial_t_inner: 10000 K
+  disable_electron_scattering: false
+  excitation: dilute-lte
+  ionization: nebular
+  line_interaction_type: downbranch
+  radiative_rates_type: dilute-blackbody
+spectrum:
+  num: 10000
+  start: 500 angstrom
+  stop: 20000 angstrom
+supernova:
+  luminosity_requested: 9.44 log_lsun
+  time_explosion: 13. day
+tardis_config_version: v1.0


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

This PR aims at creating a copy of old config files used by tardis integration tests.


### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
